### PR TITLE
Unit test for dropping privilege

### DIFF
--- a/config/mkdirall.go
+++ b/config/mkdirall.go
@@ -129,7 +129,7 @@ func setFileAndDirPerms(paths []string, dirPerm os.FileMode, perm os.FileMode, u
 		}
 	}
 	for dir := range dirs {
-		filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
@@ -144,7 +144,9 @@ func setFileAndDirPerms(paths []string, dirPerm os.FileMode, perm os.FileMode, u
 				return errors.Wrapf(err, "Failed to chown directory %v", path)
 			}
 			return nil
-		})
+		}); err != nil {
+			return errors.Wrapf(err, "Failed to walk directory %v", dir)
+		}
 	}
 	return nil
 }
@@ -166,7 +168,7 @@ func setDirPerms(paths []string, dirPerm os.FileMode, perm os.FileMode, uid int,
 		if err = os.Chown(dir, uid, gid); err != nil {
 			return errors.Wrapf(err, "Failed to chown directory %v", dir)
 		}
-		filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
@@ -181,7 +183,9 @@ func setDirPerms(paths []string, dirPerm os.FileMode, perm os.FileMode, uid int,
 				return errors.Wrapf(err, "Failed to chown directory %v", path)
 			}
 			return nil
-		})
+		}); err != nil {
+			return errors.Wrapf(err, "Failed to walk directory %v", dir)
+		}
 	}
 	return nil
 }

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -44,6 +44,7 @@ Server:
   RegistrationRetryInterval: 10s
   StartupTimeout: 10s
   UILoginRateLimit: 1
+  UnprivilegedUser: pelican
 Director:
   DefaultResponse: cache
   CacheSortMethod: "distance"

--- a/daemon/launch_windows.go
+++ b/daemon/launch_windows.go
@@ -36,6 +36,12 @@ func (launcher DaemonLauncher) Launch(ctx context.Context) (context.Context, int
 	return context.Background(), -1, errors.New("launching daemons is not supported on Windows")
 }
 
+func (launcher DaemonLauncher) KillFunc() func(pid int, sig int) error {
+	return func(pid int, sig int) error {
+		return errors.New("killing daemons is not supported on Windows")
+	}
+}
+
 func ForwardCommandToLogger(ctx context.Context, daemonName string, cmdStdout io.ReadCloser, cmdStderr io.ReadCloser) {
 	return
 }

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2002,6 +2002,21 @@ type: bool
 default: false
 components: ["*"]
 ---
+name: Server.DropPrivileges
+description: |+
+  If the server has been started with root privileges, drop down to an unprivileged user.
+type: bool
+default: false
+components: ["*"]
+---
+name: Server.UnprivilegedUser
+description: |+
+  The user to run as after dropping root privileges.
+  This is only relevant if `Server.DropPrivileges` is set to true
+type: string
+default: pelican
+components: ["*"]
+---
 ################################
 #   Issuer's Configurations    #
 ################################

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -85,7 +85,7 @@ RUN yum -y update \
 ####
 FROM dependency-build AS xrootd-plugin-builder
 # Install necessary build dependencies
-RUN  yum install -y --enablerepo=osg-testing xrootd-devel xrootd-server-devel xrootd-client-devel curl-devel openssl-devel git cmake3 gcc-c++ sqlite-devel
+RUN  yum install -y --enablerepo=osg-testing xrootd-devel xrootd-server-devel xrootd-client-devel xrootd-private-devel curl-devel openssl-devel git cmake3 gcc-c++ sqlite-devel
 
 # The ADD command with a api.github.com URL in the next couple of sections
 # are for cache-hashing of the external repository that we rely on to build
@@ -124,8 +124,8 @@ RUN git clone https://github.com/pboettch/json-schema-validator.git && \
     cd json-schema-validator && mkdir build && \
     cd build && cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX=/usr .. && \
     make -j`nproc` install
-#Finally LotMan proper. For now we do this from source until we can sort out the RPMs.
-#Ping LotMan at a specific commit
+# LotMan proper. For now we do this from source until we can sort out the RPMs.
+# Pin LotMan at a specific commit
 RUN \
     git clone https://github.com/PelicanPlatform/lotman.git && \
     cd lotman && \
@@ -133,6 +133,15 @@ RUN \
     mkdir build && cd build && \
     # LotMan CMakeLists.txt needs to be updated to use -DLIB_INSTALL_DIR. Issue #6
     cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
+    make -j`nproc` install
+
+# XrdHttp plugin for Pelican.  Provides a control channel for shutdown and updating TLS files
+RUN \
+    git clone https://github.com/PelicanPlatform/xrdhttp-pelican.git && \
+    cd /xrdhttp-pelican && \
+    git checkout v0.0.2 && \
+    mkdir build && cd build && \
+    cmake -DLIB_INSTALL_DIR=/usr/lib64 .. && \
     make -j`nproc` install
 
 FROM dependency-build AS final-stage
@@ -207,7 +216,7 @@ COPY --from=xrootd-plugin-builder /etc/xrootd/client.plugins.d/pelican-plugin.co
 RUN rm -f /etc/xrootd/client.plugins.d/xrdcl-http-plugin.conf
 
 # Copy built s3 plugin library and xrdcl-pelican plugin library from build
-COPY --from=xrootd-plugin-builder /usr/lib64/libXrdS3-5.so /usr/lib64/libXrdHTTPServer-5.so /usr/lib64/libXrdClPelican-5.so \
+COPY --from=xrootd-plugin-builder /usr/lib64/libXrdHttpPelican-5.so /usr/lib64/libXrdS3-5.so /usr/lib64/libXrdHTTPServer-5.so /usr/lib64/libXrdClPelican-5.so \
     /usr/lib64/libLotMan.so /usr/lib64/
 
 # Copy the nlohmann json headers

--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -52,7 +52,7 @@ enabled=1 \n\
 gpgcheck=0' > /etc/yum.repos.d/goreleaser.repo
 
 # Install goreleaser and various other packages we need
-RUN yum install -y --enablerepo=osg-testing goreleaser npm xrootd-devel xrootd-server-devel xrootd-client-devel nano xrootd-scitokens xrootd-voms \
+RUN yum install -y --enablerepo=osg-testing goreleaser npm xrootd-devel xrootd-server-devel xrootd-private-devel xrootd-client-devel nano xrootd-scitokens xrootd-voms \
     xrdcl-http jq procps docker make curl-devel java-17-openjdk-headless git cmake3 gcc-c++ openssl-devel sqlite-devel libcap-devel sssd-client \
     xrootd-multiuser \
     zlib-devel \
@@ -84,6 +84,15 @@ RUN \
     cd xrootd-s3-http && \
     git checkout v0.1.8 && \
     git submodule update --init --recursive && \
+    mkdir build && cd build && \
+    cmake -DLIB_INSTALL_DIR=/usr/lib64 .. && \
+    make install
+
+# Similarly, install the XrdHttp plugin for Pelican
+RUN \
+    git clone https://github.com/PelicanPlatform/xrdhttp-pelican.git && \
+    cd xrdhttp-pelican && \
+    git checkout v0.0.2 && \
     mkdir build && cd build && \
     cmake -DLIB_INSTALL_DIR=/usr/lib64 .. && \
     make install

--- a/launchers/droppriv_unix.go
+++ b/launchers/droppriv_unix.go
@@ -1,0 +1,56 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package launchers
+
+import (
+	"syscall"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+func dropPriveleges() (err error) {
+	log.Info("Dropping privileges to user ", param.Server_UnprivilegedUser.GetString())
+	var puser config.User
+	puser, err = config.GetPelicanUser()
+	if err != nil {
+		return
+	}
+	if puser.Uid == 0 {
+		err = errors.Errorf("unable to drop privileges to user (%s) with UID 0", puser.Username)
+		return
+	}
+	if puser.Gid == 0 {
+		err = errors.Errorf("unable to drop privileges to user (user %s, group %s) with GID 0", puser.Username, puser.Groupname)
+		return
+	}
+	if err = syscall.Setgid(puser.Gid); err != nil {
+		err = errors.Wrap(err, "failed to drop group privileges")
+		return
+	}
+	if err = syscall.Setuid(puser.Uid); err != nil {
+		err = errors.Wrap(err, "failed to drop user privileges")
+		return
+	}
+	return
+}

--- a/launchers/droppriv_windows.go
+++ b/launchers/droppriv_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package launchers
+
+import "github.com/pkg/errors"
+
+func dropPriveleges() (err error) {
+	return errors.New("dropping privileges is not supported on Windows")
+}

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -325,6 +325,13 @@ func LaunchModules(ctx context.Context, modules server_structs.ServerType) (serv
 		}
 	}
 
+	// Now that we've launched XRootD (which should drop their privileges to the xrootd user), we can drop our own
+	if config.IsRootExecution() && param.Server_DropPrivileges.GetBool() {
+		if err = dropPriveleges(); err != nil {
+			return
+		}
+	}
+
 	if modules.IsEnabled(server_structs.OriginType) || modules.IsEnabled(server_structs.CacheType) {
 		log.Debug("Launching periodic advertise of origin/cache server to the director")
 		if err = launcher_utils.LaunchPeriodicAdvertise(ctx, egrp, servers); err != nil {

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -254,6 +254,7 @@ var (
 	Server_TLSKey = StringParam{"Server.TLSKey"}
 	Server_UIActivationCodeFile = StringParam{"Server.UIActivationCodeFile"}
 	Server_UIPasswordFile = StringParam{"Server.UIPasswordFile"}
+	Server_UnprivilegedUser = StringParam{"Server.UnprivilegedUser"}
 	Server_WebConfigFile = StringParam{"Server.WebConfigFile"}
 	Server_WebHost = StringParam{"Server.WebHost"}
 	Shoveler_AMQPExchange = StringParam{"Shoveler.AMQPExchange"}
@@ -375,6 +376,7 @@ var (
 	Registry_RequireCacheApproval = BoolParam{"Registry.RequireCacheApproval"}
 	Registry_RequireKeyChaining = BoolParam{"Registry.RequireKeyChaining"}
 	Registry_RequireOriginApproval = BoolParam{"Registry.RequireOriginApproval"}
+	Server_DropPrivileges = BoolParam{"Server.DropPrivileges"}
 	Server_EnablePprof = BoolParam{"Server.EnablePprof"}
 	Server_EnableUI = BoolParam{"Server.EnableUI"}
 	Shoveler_Enable = BoolParam{"Shoveler.Enable"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -252,6 +252,7 @@ type Config struct {
 		RequireOriginApproval bool `mapstructure:"requireoriginapproval" yaml:"RequireOriginApproval"`
 	} `mapstructure:"registry" yaml:"Registry"`
 	Server struct {
+		DropPrivileges bool `mapstructure:"dropprivileges" yaml:"DropPrivileges"`
 		EnablePprof bool `mapstructure:"enablepprof" yaml:"EnablePprof"`
 		EnableUI bool `mapstructure:"enableui" yaml:"EnableUI"`
 		ExternalWebUrl string `mapstructure:"externalweburl" yaml:"ExternalWebUrl"`
@@ -274,6 +275,7 @@ type Config struct {
 		UIAdminUsers []string `mapstructure:"uiadminusers" yaml:"UIAdminUsers"`
 		UILoginRateLimit int `mapstructure:"uiloginratelimit" yaml:"UILoginRateLimit"`
 		UIPasswordFile string `mapstructure:"uipasswordfile" yaml:"UIPasswordFile"`
+		UnprivilegedUser string `mapstructure:"unprivilegeduser" yaml:"UnprivilegedUser"`
 		WebConfigFile string `mapstructure:"webconfigfile" yaml:"WebConfigFile"`
 		WebHost string `mapstructure:"webhost" yaml:"WebHost"`
 		WebPort int `mapstructure:"webport" yaml:"WebPort"`
@@ -564,6 +566,7 @@ type configWithType struct {
 		RequireOriginApproval struct { Type string; Value bool }
 	}
 	Server struct {
+		DropPrivileges struct { Type string; Value bool }
 		EnablePprof struct { Type string; Value bool }
 		EnableUI struct { Type string; Value bool }
 		ExternalWebUrl struct { Type string; Value string }
@@ -586,6 +589,7 @@ type configWithType struct {
 		UIAdminUsers struct { Type string; Value []string }
 		UILoginRateLimit struct { Type string; Value int }
 		UIPasswordFile struct { Type string; Value string }
+		UnprivilegedUser struct { Type string; Value string }
 		WebConfigFile struct { Type string; Value string }
 		WebHost struct { Type string; Value string }
 		WebPort struct { Type string; Value int }

--- a/xrootd/commsocket_default.go
+++ b/xrootd/commsocket_default.go
@@ -1,0 +1,74 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package xrootd
+
+import (
+	"os"
+	"syscall"
+)
+
+var (
+	g_origin_fds [2]int
+	g_cache_fds  [2]int
+)
+
+func init() {
+	g_origin_fds = [2]int{-1, -1}
+	g_cache_fds = [2]int{-1, -1}
+}
+
+// Set the global copy of the origin's communication FDs
+// To be used later for sending updated CAs and host certificates.
+func setOriginFds(fds [2]int) {
+	g_origin_fds = fds
+}
+
+// Set the global copy of the cache's communication FDs
+// To be used later for sending updated CAs and host certificates.
+func setCacheFds(fds [2]int) {
+	g_cache_fds = fds
+}
+
+// Send a provided file descriptor to a child xrootd process.
+// If the `origin` is true, it'll send the FD to origin;
+// otherwise, it'll send it to cache.
+// If the origin/cache FD is not set, it'll return nil.
+func sendChildFD(origin bool, cmd int, fp *os.File) error {
+	rights := syscall.UnixRights(int(fp.Fd()))
+	if origin {
+		if g_origin_fds[0] == -1 {
+			return nil
+		}
+		return syscall.Sendmsg(g_origin_fds[0], []byte{byte(cmd)}, rights, nil, 0)
+	}
+	if g_cache_fds[0] == -1 {
+		return nil
+	}
+	return syscall.Sendmsg(g_cache_fds[0], []byte{byte(cmd)}, rights, nil, 0)
+}
+
+// Close the child socket
+func closeChildSocket(origin bool) error {
+	if origin {
+		return syscall.Close(g_origin_fds[0])
+	}
+	return syscall.Close(g_cache_fds[0])
+}

--- a/xrootd/commsocket_windows.go
+++ b/xrootd/commsocket_windows.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 /***************************************************************
  *
  * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
@@ -16,29 +18,26 @@
  *
  ***************************************************************/
 
-package daemon
+package xrootd
 
 import (
-	"context"
+	"os"
+
+	"github.com/pkg/errors"
 )
 
-type (
-	Launcher interface {
-		Name() string
-		Launch(ctx context.Context) (context.Context, int, error)
-		KillFunc() func(pid int, sig int) error
-	}
+// Set the origin's FDs; not implemented on Windows
+func setOriginFds([2]int) {}
 
-	DaemonLauncher struct {
-		DaemonName string
-		Args       []string
-		Uid        int
-		Gid        int
-		ExtraEnv   []string
-		InheritFds []int
-	}
-)
+// Set the cache's FDs; not implemented on Windows
+func setCacheFds([2]int) {}
 
-func (launcher DaemonLauncher) Name() string {
-	return launcher.DaemonName
+// Send a provided file descriptor to a child xrootd process; not implemented on Windows
+func sendChildFD(bool, int, *os.File) error {
+	return errors.New("sendChildFD not implemented on Windows")
+}
+
+// Close the child socket; not implemented on Windows
+func closeChildSocket(origin bool) error {
+	return errors.New("closeChildSocket not implemented on Windows")
 }

--- a/xrootd/drop_privilege_test.go
+++ b/xrootd/drop_privilege_test.go
@@ -1,0 +1,218 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package xrootd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/origin"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/test_utils"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	CmdUpdateCA = 1
+)
+
+// isValidFD checks if a file descriptor is valid.
+func isValidFD(fd int) (bool, error) {
+	if fd < 0 {
+		return false, nil
+	}
+	var stat syscall.Stat_t
+	err := syscall.Fstat(fd, &stat)
+	if err != nil && err != syscall.EBADF {
+		return false, err
+	}
+	return true, err
+}
+
+func mockXRootDProcess(t *testing.T, fds [2]int, ready chan<- struct{}) {
+	t.Logf("Mock XRootD Process started. FDs: %v", fds)
+	close(ready) // Signal that mockXRootDProcess is ready
+
+	commandBuf := make([]byte, 1)
+
+	// Read the command byte sent by the another process
+	n, err := syscall.Read(fds[0], commandBuf)
+	if err != nil {
+		t.Errorf("Mock XRootD: Error receiving command: %v", err)
+		return
+	}
+	if n != 1 {
+		t.Errorf("Mock XRootD: Expected to read 1 command byte, but read: %d", n)
+		return
+	}
+
+	cmd := commandBuf[0]
+
+	switch cmd {
+	case byte(CmdUpdateCA):
+		t.Log("Mock XRootD: Received CmdUpdateCA")
+	default:
+		t.Errorf("Mock XRootD received unexpected command")
+		return
+	}
+}
+
+func startMockXrootdProcess(t *testing.T, isOrigin bool) (ready <-chan struct{}) {
+	readyChan := make(chan struct{})
+	ready = readyChan
+
+	var targetFds *[2]int
+	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	require.NoError(t, err)
+	if isOrigin {
+		g_origin_fds = [2]int{fds[0], fds[1]}
+		targetFds = &g_origin_fds
+	} else {
+		g_cache_fds = [2]int{fds[0], fds[1]}
+		targetFds = &g_cache_fds
+	}
+
+	isValidFD, err := isValidFD(g_origin_fds[1])
+	require.True(t, isValidFD, "Write file descriptor is not valid (os.Stat err)")
+	require.NoError(t, err)
+
+	go mockXRootDProcess(t, *targetFds, readyChan)
+
+	return ready
+}
+
+// receiveFD reads the file descriptor from its global variable
+func receiveFD(isOrigin bool) (int, error) {
+	var readFD int
+
+	if isOrigin {
+		readFD = g_origin_fds[0]
+	} else {
+		readFD = g_cache_fds[0]
+	}
+
+	isValid, err := isValidFD(readFD)
+	if !isValid || err != nil {
+		return -1, fmt.Errorf("invalid FD: %d %w", readFD, err)
+	}
+
+	return readFD, nil
+}
+
+// generateTestCert generates a self-signed certificate and key for testing
+func generateTestCert(runDir string) (certPath, keyPath string, err error) {
+	// Create cert and key files
+	certPath = filepath.Join(runDir, "cert.pem")
+	keyPath = filepath.Join(runDir, "key.pem")
+
+	viper.Set("IssuerKey", keyPath)
+	viper.Set("Server.TLSCertificateChain", certPath)
+	viper.Set("Server.TLSKey", keyPath)
+	viper.Set("Server.TLSCACertificateFile", filepath.Join(runDir, "ca.pem"))
+	viper.Set("Server.TLSCAKey", filepath.Join(runDir, "ca-key.pem"))
+	viper.Set("Server.Hostname", "localhost")
+
+	err = config.GenerateCert() // GenerateCert uses the viper config set above
+
+	return certPath, keyPath, err
+}
+
+func TestDropPrivilegeSignaling(t *testing.T) {
+	_, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	t.Cleanup(func() {
+		cancel()
+		require.NoError(t, egrp.Wait())
+		server_utils.ResetTestState()
+	})
+
+	runDir := t.TempDir()
+	viper.Set("Origin.RunLocation", runDir)
+	viper.Set("Cache.RunLocation", runDir)
+	viper.Set("ConfigDir", runDir)
+	config.InitConfig()
+
+	pelicanDir := filepath.Join(runDir, "pelican")
+	err := os.Mkdir(pelicanDir, 0755)
+	require.NoError(t, err, "Failed to create pelican directory")
+
+	// Set the configuration parameters before calling any xrootd functions
+	certFile, keyFile, err := generateTestCert(runDir)
+	require.NoError(t, err, "Failed to generate test certificate")
+
+	require.NotEmpty(t, certFile, "Empty certificate file path")
+	require.NotEmpty(t, keyFile, "Empty key file path")
+
+	// Dummy CA bundle data
+	caBundleData := []byte("Test CA Bundle Content")
+	caBundleFile := filepath.Join(runDir, "ca-bundle.crt")
+	require.NoError(t, os.WriteFile(caBundleFile, caBundleData, 0644))
+
+	// Open the CA bundle file
+	caBundle, err := os.Open(caBundleFile)
+	require.NoError(t, err, "Failed to open CA bundle file")
+	defer caBundle.Close()
+
+	isOrigin := true
+	// Start mock XRootD (sets up the IPC)
+	ready := startMockXrootdProcess(t, isOrigin)
+	defer closeChildSocket(isOrigin)
+
+	// The ready channel signals to the test function that the mock XRootD process is ready to receive data (the command byte)
+	<-ready
+
+	viper.Set("Server.DropPrivileges", true)
+
+	// Send the command byte BEFORE calling dropPrivilegeCopy
+	command := []byte{byte(CmdUpdateCA)}
+
+	if isOrigin {
+		// Verify FD is valid before writing
+		isValidFD, err := isValidFD(g_origin_fds[1])
+		require.True(t, isValidFD, "Write file descriptor is not valid (os.Stat err)")
+		require.NoError(t, err)
+
+		t.Log("Global origin FDs: ", g_origin_fds)
+		t.Logf("Writing %x to fd %d", command, g_origin_fds[1])
+
+		n, err := syscall.Write(g_origin_fds[1], command)
+		require.NoError(t, err, "Failed to send command byte")
+		require.Equal(t, 1, n, "Expected to write 1 byte")
+	} else {
+		_, err = syscall.Write(g_cache_fds[1], command)
+		require.NoError(t, err, "Failed to send command byte")
+	}
+
+	// Call the function under test
+	t.Logf("Before dropPrivilegeCopy, g_origin_fds: %v", g_origin_fds)
+	err = dropPrivilegeCopy(&origin.OriginServer{})
+	require.NoError(t, err, "dropPrivilegeCopy failed")
+	t.Logf("After dropPrivilegeCopy, g_origin_fds: %v", g_origin_fds)
+
+	// Get the file descriptor sent by dropPrivilegeCopy
+	_, err = receiveFD(isOrigin)
+	require.NoError(t, err)
+}

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -32,6 +32,9 @@ http.header2cgi X-Pelican-Timeout pelican.timeout
 http.secxtractor /usr/lib64/libXrdVoms.so
 {{end}}
 http.staticpreload http://static/robots.txt {{.Xrootd.RobotsTxtFile}}
+{{if .Server.DropPrivileges}}
+http.exthandler xrdpelican libXrdHttpPelican.so
+{{end}}
 {{if .Xrootd.Sitename}}
 all.sitename {{.Xrootd.Sitename}}
 {{end}}

--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -112,6 +112,9 @@ xrootd.export /.well-known
 ofs.osslib libXrdMultiuser.so default
 ofs.ckslib * libXrdMultiuser.so
 {{end}}
+{{if .Server.DropPrivileges}}
+http.exthandler xrdpelican libXrdHttpPelican.so
+{{end}}
 xrootd.fslib ++ throttle  # throttle plugin is needed to calculate server IO load
 xrootd.chksum max 2 md5 adler32 crc32
 xrootd.trace {{.Logging.OriginXrootd}}

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -721,14 +721,14 @@ func TestCopyCertificates(t *testing.T) {
 	config.InitConfig()
 
 	// First, invoke CopyXrootdCertificates directly, ensure it works.
-	err := CopyXrootdCertificates(&origin.OriginServer{})
+	err := copyXrootdCertificates(&origin.OriginServer{})
 	assert.ErrorIs(t, err, errBadKeyPair)
 
 	err = config.InitServer(ctx, server_structs.OriginType)
 	require.NoError(t, err)
 	err = config.MkdirAll(path.Dir(param.Xrootd_Authfile.GetString()), 0755, -1, -1)
 	require.NoError(t, err)
-	err = CopyXrootdCertificates(&origin.OriginServer{})
+	err = copyXrootdCertificates(&origin.OriginServer{})
 	require.NoError(t, err)
 	destKeyPairName := filepath.Join(param.Origin_RunLocation.GetString(), "copied-tls-creds.crt")
 	assert.FileExists(t, destKeyPairName)
@@ -748,7 +748,7 @@ func TestCopyCertificates(t *testing.T) {
 	err = os.Rename(certName, certName+".orig")
 	require.NoError(t, err)
 
-	err = CopyXrootdCertificates(&origin.OriginServer{})
+	err = copyXrootdCertificates(&origin.OriginServer{})
 	assert.ErrorIs(t, err, errBadKeyPair)
 
 	err = os.Rename(keyName, keyName+".orig")
@@ -757,7 +757,7 @@ func TestCopyCertificates(t *testing.T) {
 	err = config.InitServer(ctx, server_structs.OriginType)
 	require.NoError(t, err)
 
-	err = CopyXrootdCertificates(&origin.OriginServer{})
+	err = copyXrootdCertificates(&origin.OriginServer{})
 	require.NoError(t, err)
 
 	secondKeyPairContents, err := os.ReadFile(destKeyPairName)


### PR DESCRIPTION
This PR adds a unit test to the signaling between Pelican and XRootD processes.
It also fixes few linter problems in the original PR.

I rebased this branch to the latest main this week, so that's why there are so many commits from others in this PR right now. They should be gone once @bbockelm rebases his `bbockelm:drop_privs` branch up-to-date.